### PR TITLE
Gsim withdrawal fix & Encryption Key DB Store

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/domain/EncryptionKey.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/domain/EncryptionKey.java
@@ -42,11 +42,11 @@ public class EncryptionKey extends AbstractPersistableCustom {
 
     @Lob
     @Column(name = "public_key", nullable = false)
-    private byte[] publicKey;
+    private String publicKey;
 
     @Lob
     @Column(name = "private_key", nullable = false)
-    private byte[] privateKey;
+    private String privateKey;
 
     @Column(name = "version", nullable = false)
     private String version;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/domain/EncryptionKey.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/domain/EncryptionKey.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.crypt.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+
+@Entity
+@Table(name = "m_encryption_keys")
+@Getter
+@Setter
+@NoArgsConstructor
+@Accessors(chain = true)
+public class EncryptionKey extends AbstractPersistableCustom {
+
+    @Column(name = "key_type", nullable = false)
+    private String keyType;
+
+    @Lob
+    @Column(name = "public_key", nullable = false)
+    private byte[] publicKey;
+
+    @Lob
+    @Column(name = "private_key", nullable = false)
+    private byte[] privateKey;
+
+    @Column(name = "version", nullable = false)
+    private String version;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/repository/EncryptionKeyRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/repository/EncryptionKeyRepository.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.crypt.repository;
+
+import org.apache.fineract.infrastructure.crypt.domain.EncryptionKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface EncryptionKeyRepository
+        extends JpaRepository<EncryptionKey, Long>, JpaSpecificationExecutor<EncryptionKey> {
+
+    EncryptionKey findByKeyType(String keyType);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java
@@ -20,21 +20,18 @@ package org.apache.fineract.infrastructure.crypt.service;
 
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.inject.Singleton;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
-import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.crypt.domain.EncryptionKeyPair;
 import org.apache.fineract.infrastructure.crypt.utils.RSAEncryptionUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
+
+import org.apache.fineract.infrastructure.crypt.domain.EncryptionKey;
+import org.apache.fineract.infrastructure.crypt.repository.EncryptionKeyRepository;
 
 /**
  * @author manoj
@@ -42,22 +39,38 @@ import org.springframework.stereotype.Service;
 @Service
 @Singleton
 public class EncryptionKeyStoreServiceImpl  implements EncryptionKeyStoreService{
-    private Map<String, EncryptionKeyPair> keyMap =  new ConcurrentHashMap<>();
+    private final EncryptionKeyRepository encryptionKeyRepository;
 
 
     private final ConfigurationDomainService configurationDomainService;
     private final RSAEncryptionUtils rsaEncryptionUtils;
 
     @Autowired
-    public EncryptionKeyStoreServiceImpl(ConfigurationDomainService configurationDomainService, RSAEncryptionUtils rsaEncryptionUtils) {
+    public EncryptionKeyStoreServiceImpl(
+            ConfigurationDomainService configurationDomainService,
+            RSAEncryptionUtils rsaEncryptionUtils,
+            EncryptionKeyRepository encryptionKeyRepository) {
         this.configurationDomainService = configurationDomainService;
         this.rsaEncryptionUtils = rsaEncryptionUtils;
+        this.encryptionKeyRepository = encryptionKeyRepository;
     }
 
-    @Caching(evict = {
-            @CacheEvict(value = "encryptionKeys", key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat(#type)")})
-    public void storeKey(String type, EncryptionKeyPair key){
-        this.keyMap.put(getKeyType(type), key);
+
+    private void storeKey(String type, EncryptionKeyPair key) {
+
+        EncryptionKey entity = encryptionKeyRepository.findByKeyType(type);
+
+        if (entity == null) {
+            entity = new EncryptionKey();
+            entity.setKeyType(type);
+        }
+
+        entity.setPublicKey(key.getPublicKey());
+        entity.setPrivateKey(key.getPrivateKey());
+        entity.setVersion(key.getVersion());
+        entity.setCreatedAt(key.getCreatedDateTime());
+
+        encryptionKeyRepository.save(entity);
     }
 
     private EncryptionKeyPair retrieveValidKey(String type){
@@ -81,15 +94,22 @@ public class EncryptionKeyStoreServiceImpl  implements EncryptionKeyStoreService
         return null;
     }
 
-        @Cacheable(value = "encryptionKeys", key = "T(org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil).getTenant().getTenantIdentifier().concat(#type)")
-    public EncryptionKeyPair getKeys(String type){
-        return this.keyMap.get(getKeyType(type));
-    }
 
-    private String getKeyType(String type){
-        return (type + ThreadLocalContextUtil.getTenant().getTenantIdentifier());
-    }
+    private EncryptionKeyPair getKeys(String type) {
 
+        EncryptionKey entity = encryptionKeyRepository.findByKeyType(type);
+
+        if (entity == null) {
+            return null;
+        }
+
+        return new EncryptionKeyPair(
+                entity.getPrivateKey(),
+                entity.getPublicKey(),
+                entity.getCreatedAt(),
+                entity.getVersion()
+        );
+    }
 
     @Override
     public EncryptionKeyPair retrieveKey(String type){

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java
@@ -20,6 +20,7 @@ package org.apache.fineract.infrastructure.crypt.service;
 
 
 import java.time.Duration;
+import java.util.Base64;
 
 import jakarta.inject.Singleton;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
@@ -65,8 +66,11 @@ public class EncryptionKeyStoreServiceImpl  implements EncryptionKeyStoreService
             entity.setKeyType(type);
         }
 
-        entity.setPublicKey(key.getPublicKey());
-        entity.setPrivateKey(key.getPrivateKey());
+        entity.setPublicKey(
+                Base64.getEncoder().encodeToString(key.getPublicKey()));
+
+        entity.setPrivateKey(
+                Base64.getEncoder().encodeToString(key.getPrivateKey()));
         entity.setVersion(key.getVersion());
         entity.setCreatedAt(key.getCreatedDateTime());
 
@@ -104,8 +108,8 @@ public class EncryptionKeyStoreServiceImpl  implements EncryptionKeyStoreService
         }
 
         return new EncryptionKeyPair(
-                entity.getPrivateKey(),
-                entity.getPublicKey(),
+                Base64.getDecoder().decode(entity.getPrivateKey()),
+                Base64.getDecoder().decode(entity.getPublicKey()),
                 entity.getCreatedAt(),
                 entity.getVersion()
         );

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/savings/service/SavingsAccountWritePlatformServiceJpaRepositoryImpl.java
@@ -396,7 +396,9 @@ public class SavingsAccountWritePlatformServiceJpaRepositoryImpl implements Savi
             this.noteRepository.save(note);
         }
         //todo: move this from here
-        changes.put("clientMob", account.getClient().getMobileNo());
+        if (account.getClient() != null) {
+            changes.put("clientMob", account.getClient().getMobileNo());
+        }
         return new CommandProcessingResultBuilder() //
                 .withEntityId(withdrawal.getId()) //
                 .withOfficeId(account.officeId()) //

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -153,4 +153,5 @@
     <include file="parts/0131_create_user_session.xml" relativeToChangelogFile="true" />
     <include file="parts/0133_alter_appuser_add_bad_cred_count.xml" relativeToChangelogFile="true" />
     <include file="parts/0134_add_credentials_locked_at_column.xml" relativeToChangelogFile="true"/>
+    <include file="parts/0135_add_encryption_keys.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0135_add_encryption_keys.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0135_add_encryption_keys.xml
@@ -36,11 +36,11 @@ under the License.
                 <constraints nullable="false"/>
             </column>
 
-            <column name="public_key" type="BLOB">
+            <column name="public_key" type="TEXT">
                 <constraints nullable="false"/>
             </column>
 
-            <column name="private_key" type="BLOB">
+            <column name="private_key" type="TEXT">
                 <constraints nullable="false"/>
             </column>
 

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0135_add_encryption_keys.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0135_add_encryption_keys.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="0135" author="pareekshith">
+
+        <createTable tableName="m_encryption_keys">
+
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true"
+                             nullable="false"/>
+            </column>
+
+            <column name="key_type" type="VARCHAR(100)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="public_key" type="BLOB">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="private_key" type="BLOB">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="version" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at"
+                    type="DATETIME"
+                    defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+
+        </createTable>
+
+        <addUniqueConstraint
+                tableName="m_encryption_keys"
+                columnNames="key_type"
+                constraintName="uk_m_encryption_keys_key_type"/>
+
+        <createIndex
+                indexName="idx_m_encryption_keys_key_type"
+                tableName="m_encryption_keys">
+
+            <column name="key_type"/>
+
+        </createIndex>
+
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
# Persist RSA encryption keys in database with Base64 encoding
## Description
### Overview

This PR replaces the in-memory RSA key storage mechanism with persistent database-backed storage.

Previously, RSA encryption keys were stored only in memory (ConcurrentHashMap). During pod restarts or Kubernetes pod scaling events, newly created pods generated different RSA key pairs, causing encrypted passwords generated using one pod's public key to fail decryption on another pod.

This implementation introduces persistent key storage in the database, ensuring that all application instances use the same RSA key pair.

Additionally, the RSA keys are stored in Base64 encoded format instead of raw binary (BLOB), making them easier to inspect and manage while preserving the original key data.

### Files Added 
1) db/changelog/tenant/parts/0135_add_encryption_keys.xml
2) EncryptionKey.java
3) EncryptionKeyRepository.java

###Major changes include:

Removed in-memory key persistence
Added database-backed key retrieval
Added database-backed key persistence
Added Base64 encoding before storing keys
Added Base64 decoding while retrieving keys
Preserved existing key rotation logic
Preserved existing key expiry validation

### Tests 

1) Key Generation

<img width="1067" height="642" alt="pbkey" src="https://github.com/user-attachments/assets/3fee2575-c267-464e-a0c0-56df6aabf47a" />

2) Database Persistence

<img width="621" height="31" alt="encry" src="https://github.com/user-attachments/assets/53be7b2e-8742-4a19-935b-7ca6ee3a69d7" />


<img width="1160" height="100" alt="image" src="https://github.com/user-attachments/assets/694d3a87-2b53-46e3-b11e-0a92fa642920" />

3) Authentication 

Successful authentication using the password which was generated and stored inside the db

<img width="1101" height="905" alt="image" src="https://github.com/user-attachments/assets/02c11c88-8b90-41bd-802c-c0e6609b17fa" />

# Fix GSIM Withdrawal NullPointerException

## Prevent NullPointerException during GSIM withdrawal
### Description
### Overview

This PR fixes a NullPointerException occurring while performing withdrawals from Group Savings with Individual Monitoring (GSIM) accounts.

For GSIM accounts, the savings account is associated with a Group rather than an individual Client.

During withdrawal processing, the application attempted to access the client's mobile number without verifying whether a client was associated with the account.

This resulted in a 500 Internal Server Error.

### Files Modified
SavingsAccountWritePlatformServiceJpaRepositoryImpl.java

### Fix 

if (account.getClient() != null) {
            changes.put("clientMob", account.getClient().getMobileNo());
        }

<img width="1267" height="420" alt="line399 gsim change" src="https://github.com/user-attachments/assets/fbd80559-4689-4c9f-a392-6a270b9ffea5" />


These fixes are for resolving issues (ssp-6 and ssp-9)

