### PR TITLE
Added Optional

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/repository/EncryptionKeyRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/repository/EncryptionKeyRepository.java
@@ -18,6 +18,8 @@
  */
 package org.apache.fineract.infrastructure.crypt.repository;
 
+import java.util.Optional;
+
 import org.apache.fineract.infrastructure.crypt.domain.EncryptionKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -25,5 +27,5 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 public interface EncryptionKeyRepository
         extends JpaRepository<EncryptionKey, Long>, JpaSpecificationExecutor<EncryptionKey> {
 
-    EncryptionKey findByKeyType(String keyType);
+    Optional<EncryptionKey> findByKeyType(String keyType);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java
@@ -21,6 +21,7 @@ package org.apache.fineract.infrastructure.crypt.service;
 
 import java.time.Duration;
 import java.util.Base64;
+import java.util.Optional;
 
 import jakarta.inject.Singleton;
 import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
@@ -59,12 +60,12 @@ public class EncryptionKeyStoreServiceImpl  implements EncryptionKeyStoreService
 
     private void storeKey(String type, EncryptionKeyPair key) {
 
-        EncryptionKey entity = encryptionKeyRepository.findByKeyType(type);
-
-        if (entity == null) {
-            entity = new EncryptionKey();
-            entity.setKeyType(type);
-        }
+        EncryptionKey entity = encryptionKeyRepository.findByKeyType(type)
+                .orElseGet(() -> {
+                    EncryptionKey newEntity = new EncryptionKey();
+                    newEntity.setKeyType(type);
+                    return newEntity;
+                });
 
         entity.setPublicKey(
                 Base64.getEncoder().encodeToString(key.getPublicKey()));
@@ -101,18 +102,13 @@ public class EncryptionKeyStoreServiceImpl  implements EncryptionKeyStoreService
 
     private EncryptionKeyPair getKeys(String type) {
 
-        EncryptionKey entity = encryptionKeyRepository.findByKeyType(type);
-
-        if (entity == null) {
-            return null;
-        }
-
-        return new EncryptionKeyPair(
-                Base64.getDecoder().decode(entity.getPrivateKey()),
-                Base64.getDecoder().decode(entity.getPublicKey()),
-                entity.getCreatedAt(),
-                entity.getVersion()
-        );
+        return encryptionKeyRepository.findByKeyType(type)
+                .map(entity -> new EncryptionKeyPair(
+                        Base64.getDecoder().decode(entity.getPrivateKey()),
+                        Base64.getDecoder().decode(entity.getPublicKey()),
+                        entity.getCreatedAt(),
+                        entity.getVersion()))
+                .orElse(null);
     }
 
     @Override


### PR DESCRIPTION
# Changes

The changes primarily focus on improving repository usage by adopting `Optional` and refactoring the service implementation accordingly.

## Changes Made

### 1. Updated `EncryptionKeyRepository`

**File Modified**
- `EncryptionKeyRepository.java`

#### Changes
- Updated the repository method to return `Optional<EncryptionKey>` instead of `EncryptionKey`.

From:

```java
EncryptionKey findByKeyType(String keyType);
```

to 
```java
Optional<EncryptionKey> findByKeyType(String keyType);
```
### 2. Refactored EncryptionKeyStoreServiceImpl

File Modified

EncryptionKeyStoreServiceImpl.java
Changes

Updated all usages of findByKeyType() to work with Optional.

storeKey()

Refactored the entity lookup using orElseGet().

Before:

Retrieved entity
Checked for null
Created a new entity if not found

Now:

Uses Optional.orElseGet() to retrieve the existing entity or create a new one when absent.
getKeys()

Refactored the retrieval logic using Optional.map().

Before:

Checked null
Returned null if no entity existed
Manually created EncryptionKeyPair

Now:

Uses Optional.map() to transform the entity directly into EncryptionKeyPair
Uses orElse(null) when no entity exists

## Files Modified
org/apache/fineract/infrastructure/crypt/repository/EncryptionKeyRepository.java
org/apache/fineract/infrastructure/crypt/service/EncryptionKeyStoreServiceImpl.java

#### Info:  
AbstractPersistableCustom cannot be changed to AbstractPersistableCustom<Long> because it is defined as a non generic class . also the class document explicitely states  Id is always Long (and this class thus does not require generic parameterization).  

<img width="1192" height="352" alt="primg" src="https://github.com/user-attachments/assets/a37a7004-86c1-4050-9eb3-ad7edc0cbefe" />

