### PR TITLE
Delinquency events trigger setup on service level

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyWritePlatformServiceImpl.java
@@ -18,24 +18,33 @@
  */
 package org.apache.fineract.portfolio.delinquency.service;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.event.business.BusinessEventListener;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanAccountDelinquencyPauseChangedBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanDelinquencyRangeChangeBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.infrastructure.hooks.event.HookEvent;
+import org.apache.fineract.infrastructure.hooks.event.HookEventSource;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.portfolio.delinquency.api.DelinquencyApiConstants;
 import org.apache.fineract.portfolio.delinquency.data.DelinquencyBucketData;
 import org.apache.fineract.portfolio.delinquency.data.DelinquencyRangeData;
@@ -66,6 +75,8 @@ import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.context.ApplicationContext;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -82,12 +93,22 @@ public class DelinquencyWritePlatformServiceImpl implements DelinquencyWritePlat
     private final LoanRepositoryWrapper loanRepository;
     private final LoanProductRepository loanProductRepository;
     private final BusinessEventNotifierService businessEventNotifierService;
+    private final ApplicationContext applicationContext;
+    private final PlatformSecurityContext context;
+    private final ToApiJsonSerializer<Object> toApiResultJsonSerializer;
     private final LoanDelinquencyDomainService loanDelinquencyDomainService;
     private final LoanInstallmentDelinquencyTagRepository loanInstallmentDelinquencyTagRepository;
     private final DelinquencyReadPlatformService delinquencyReadPlatformService;
     private final LoanDelinquencyActionRepository loanDelinquencyActionRepository;
     private final DelinquencyActionParseAndValidator delinquencyActionParseAndValidator;
     private final DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper;
+
+    @PostConstruct
+    public void addListeners() {
+        businessEventNotifierService.addPostBusinessEventListener(
+                LoanDelinquencyRangeChangeBusinessEvent.class,
+                new DelinquencyHookListener());
+    }
 
     @Override
     public CommandProcessingResult createDelinquencyRange(JsonCommand command) {
@@ -600,6 +621,52 @@ public class DelinquencyWritePlatformServiceImpl implements DelinquencyWritePlat
                     .filter(tag -> tag.getInstallment() == null).map(tag -> tag.getId()).toList();
             if (loanInstallmentTagsForDelete.size() > 0) {
                 loanInstallmentDelinquencyTagRepository.deleteAllLoanInstallmentsTagsByIds(loanInstallmentTagsForDelete);
+            }
+        }
+    }
+
+    private final class DelinquencyHookListener
+            implements BusinessEventListener<LoanDelinquencyRangeChangeBusinessEvent> {
+
+        @Override
+        public void onBusinessEvent(LoanDelinquencyRangeChangeBusinessEvent event) {
+            try {
+
+                Loan loan = event.get();
+
+                Map<String, Object> payload = new LinkedHashMap<>();
+
+                payload.put("loanId", loan.getId());
+                payload.put("clientId", loan.getClientId());
+
+                payload.put("entityName", "LOAN");
+                payload.put("actionName", "DELINQUENCYCHANGE");
+                payload.put("timestamp", Instant.now().toString());
+
+                AppUser appUser = context.authenticatedUser();
+
+                String serializedPayload =
+                        toApiResultJsonSerializer.serialize(payload);
+
+                HookEventSource hookEventSource =
+                        new HookEventSource("LOAN", "DELINQUENCYCHANGE");
+
+                HookEvent hookEvent =
+                        new HookEvent(
+                                hookEventSource,
+                                serializedPayload,
+                                appUser,
+                                ThreadLocalContextUtil.getContext());
+
+                applicationContext.publishEvent(hookEvent);
+
+                log.info(
+                        "Published HookEvent for delinquent loan {} (client {})",
+                        loan.getId(),
+                        loan.getClientId());
+
+            } catch (Exception e) {
+                log.error("Failed to publish delinquency HookEvent", e);
             }
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/starter/DelinquencyConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/starter/DelinquencyConfiguration.java
@@ -19,6 +19,8 @@
 package org.apache.fineract.portfolio.delinquency.starter;
 
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketMappingsRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyRangeRepository;
@@ -42,6 +44,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -73,11 +76,13 @@ public class DelinquencyConfiguration {
             LoanDelinquencyDomainService loanDelinquencyDomainService,
             LoanInstallmentDelinquencyTagRepository loanInstallmentDelinquencyTagRepository,
             DelinquencyReadPlatformService delinquencyReadPlatformService, LoanDelinquencyActionRepository loanDelinquencyActionRepository,
-            DelinquencyActionParseAndValidator delinquencyActionParseAndValidator,
-            DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper) {
+                                                                           DelinquencyActionParseAndValidator delinquencyActionParseAndValidator,
+                                                                           DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper,
+                                                                           ApplicationContext applicationContext,PlatformSecurityContext context,
+                                                                           ToApiJsonSerializer<Object> toApiResultJsonSerializer) {
         return new DelinquencyWritePlatformServiceImpl(dataValidatorBucket, dataValidatorRange, repositoryRange, repositoryBucket,
                 repositoryBucketMappings, loanDelinquencyTagRepository, loanRepository, loanProductRepository, businessEventNotifierService,
-                loanDelinquencyDomainService, loanInstallmentDelinquencyTagRepository, delinquencyReadPlatformService,
+                applicationContext,context, toApiResultJsonSerializer,loanDelinquencyDomainService, loanInstallmentDelinquencyTagRepository, delinquencyReadPlatformService,
                 loanDelinquencyActionRepository, delinquencyActionParseAndValidator, delinquencyEffectivePauseHelper);
     }
 


### PR DESCRIPTION
# Publish HookEvent for Loan Delinquency Range Changes

# Summary

This PR enables delinquency events to trigger SMS gateway processing at the service layer by publishing a custom HookEvent whenever a loan's delinquency range changes.

This removes the dependency on database-trigger-based event generation for delinquency notifications and aligns the implementation with Fineract's existing Business Event and Hook framework.

## Changes

### DelinquencyWritePlatformServiceImpl.java
- Registered a `BusinessEventListener` for `LoanDelinquencyRangeChangeBusinessEvent`.
- Added a service-level listener to publish a `HookEvent` when a loan's delinquency range changes.
- Published a custom HookEvent using:
  - **Entity:** `LOAN`
  - **Action:** `DELINQUENCYCHANGE`
- Added logging and exception handling around HookEvent publication.

### DelinquencyConfiguration.java
- Updated bean configuration to inject the dependencies required for publishing HookEvents:
  - `ApplicationContext`
  - `PlatformSecurityContext`
  - `ToApiJsonSerializer<Object>`

## Files Modified

- `fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyWritePlatformServiceImpl.java`
- `fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/starter/DelinquencyConfiguration.java`

## Benefits

- Eliminates reliance on database triggers for delinquency SMS processing.
- Publishes notifications at the service layer using the existing Hook framework.
- Reuses the existing `MessageGatewayHookProcessor`.
- Keeps the implementation localized to the delinquency module.
- Maintains backward compatibility with existing functionality.
