### PR TITLE
Template_user Id Fix

### DIFF
--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0136_add_template_system_user.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0136_add_template_system_user.xml
@@ -34,8 +34,6 @@ limitations under the License.
 
         <insert tableName="m_appuser">
 
-            <column name="id" valueNumeric="4"/>
-
             <column name="is_deleted" valueBoolean="false"/>
 
             <column name="office_id" valueNumeric="1"/>
@@ -90,8 +88,9 @@ limitations under the License.
 
         <insert tableName="m_appuser_role">
 
-            <column name="appuser_id"
-                    valueNumeric="4"/>
+            <column
+                    name="appuser_id"
+                    valueComputed="(SELECT id FROM m_appuser WHERE username='template_system')"/>
 
             <column name="role_id"
                     valueNumeric="1"/>


### PR DESCRIPTION
## Summary

This PR removes the hardcoded `id` for the `template_system` service account created through Liquibase.

## Changes
- Removed the hardcoded `id` from the `m_appuser` insert statement, allowing the database to generate the next available ID.
- Updated the `m_appuser_role` insert to resolve the generated user ID dynamically using the `template_system` username instead of a fixed ID.