### PR TITLE
Separate system and application users

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java
@@ -19,6 +19,7 @@
 package org.apache.fineract.infrastructure.configuration.domain;
 
 import java.time.LocalDate;
+import java.util.Set;
 import org.apache.fineract.infrastructure.cache.domain.CacheType;
 
 public interface ConfigurationDomainService {
@@ -138,6 +139,8 @@ public interface ConfigurationDomainService {
     String retrieveReportExportS3FolderName();
 
     String getAccrualDateConfigForCharge();
+
+    Set<String> getSystemUsernames();
 
     Integer retrieveEncKeyExpirySeconds(String type);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java
@@ -33,6 +33,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -52,6 +55,8 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
     private static final String EXTERNAL_EVENT_BATCH_SIZE = "external-event-batch-size";
 
     private static final String REPORT_EXPORT_S3_FOLDER_NAME = "report-export-s3-folder-name";
+
+    private static final String SYSTEM_USERS = "system-users";
 
     public static final String CHARGE_ACCRUAL_DATE_CRITERIA = "charge-accrual-date";
     private final PermissionRepository permissionRepository;
@@ -515,6 +520,31 @@ public class ConfigurationDomainServiceJpa implements ConfigurationDomainService
         }
         return value;
     }
+
+    @Override
+    public Set<String> getSystemUsernames() {
+        try {
+            final GlobalConfigurationPropertyData property =
+                    getGlobalConfigurationPropertyData(SYSTEM_USERS);
+
+            if (property != null
+                    && property.isEnabled()
+                    && StringUtils.isNotBlank(property.getStringValue())) {
+
+                return Arrays.stream(property.getStringValue().split(","))
+                        .map(String::trim)
+                        .filter(StringUtils::isNotBlank)
+                        .collect(Collectors.toSet());
+            }
+        } catch (GlobalConfigurationPropertyNotFoundException e) {
+            log.warn(
+                    "Global configuration '{}' not found. Defaulting to empty system-users set.",
+                    SYSTEM_USERS);
+        }
+
+        return Set.of();
+    }
+
     @Override
     public Integer retrieveEncKeyExpirySeconds(String type) {
         final String propertyName = "enc-key-" + type + "-valid-upto-seconds";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/CustomTokenAuthenticationFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/CustomTokenAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.fineract.infrastructure.configuration.domain.ConfigurationDomainService;
 import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
 import org.apache.fineract.infrastructure.security.service.SessionHandlerService;
 import org.apache.fineract.infrastructure.security.service.TenantAwareJpaPlatformUserDetailsService;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 
 @Component
 public class CustomTokenAuthenticationFilter extends OncePerRequestFilter {
@@ -32,6 +34,9 @@ public class CustomTokenAuthenticationFilter extends OncePerRequestFilter {
 
     @Autowired
     private SessionHandlerService sessionHandlerService;
+
+    @Autowired
+    private ConfigurationDomainService configurationDomainService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -50,10 +55,22 @@ public class CustomTokenAuthenticationFilter extends OncePerRequestFilter {
             String username = sessionHandlerService.validateAndExtractUsername(token);
             ThreadLocalContextUtil.setAuthToken(token);
 
-            if (username != null ) {
+            if (username != null) {
+
+                final Set<String> systemUsers = configurationDomainService.getSystemUsernames();
+
+                if (systemUsers.contains(username)) {
+                    throw new BadCredentialsException(
+                            "System users are not permitted to authenticate via session tokens.");
+                }
+
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
                 UsernamePasswordAuthenticationToken auth =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities());
 
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(auth);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareBasicAuthenticationFilter.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareBasicAuthenticationFilter.java
@@ -25,6 +25,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.Set;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.StopWatch;
@@ -169,8 +170,15 @@ public class TenantAwareBasicAuthenticationFilter extends BasicAuthenticationFil
     @Override
     protected void onSuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authResult)
             throws IOException {
-        super.onSuccessfulAuthentication(request, response, authResult);
         AppUser user = (AppUser) authResult.getPrincipal();
+
+        final Set<String> systemUsers = configurationDomainService.getSystemUsernames();
+
+        if (!systemUsers.contains(user.getUsername())) {
+            throw new BadCredentialsException(
+                    "Only system users are permitted to authenticate via Basic Authentication.");
+        }
+        super.onSuccessfulAuthentication(request, response, authResult);
 
         if (userNotificationService.hasUnreadUserNotifications(user.getId())) {
             response.addHeader("X-Notification-Refresh", "true");

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/service/DelinquencyWritePlatformServiceImpl.java
@@ -18,24 +18,33 @@
  */
 package org.apache.fineract.portfolio.delinquency.service;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.core.service.ThreadLocalContextUtil;
+import org.apache.fineract.infrastructure.event.business.BusinessEventListener;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanAccountDelinquencyPauseChangedBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.domain.loan.LoanDelinquencyRangeChangeBusinessEvent;
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.infrastructure.hooks.event.HookEvent;
+import org.apache.fineract.infrastructure.hooks.event.HookEventSource;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.portfolio.delinquency.api.DelinquencyApiConstants;
 import org.apache.fineract.portfolio.delinquency.data.DelinquencyBucketData;
 import org.apache.fineract.portfolio.delinquency.data.DelinquencyRangeData;
@@ -66,6 +75,8 @@ import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
+import org.apache.fineract.useradministration.domain.AppUser;
+import org.springframework.context.ApplicationContext;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
@@ -82,12 +93,22 @@ public class DelinquencyWritePlatformServiceImpl implements DelinquencyWritePlat
     private final LoanRepositoryWrapper loanRepository;
     private final LoanProductRepository loanProductRepository;
     private final BusinessEventNotifierService businessEventNotifierService;
+    private final ApplicationContext applicationContext;
+    private final PlatformSecurityContext context;
+    private final ToApiJsonSerializer<Object> toApiResultJsonSerializer;
     private final LoanDelinquencyDomainService loanDelinquencyDomainService;
     private final LoanInstallmentDelinquencyTagRepository loanInstallmentDelinquencyTagRepository;
     private final DelinquencyReadPlatformService delinquencyReadPlatformService;
     private final LoanDelinquencyActionRepository loanDelinquencyActionRepository;
     private final DelinquencyActionParseAndValidator delinquencyActionParseAndValidator;
     private final DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper;
+
+    @PostConstruct
+    public void addListeners() {
+        businessEventNotifierService.addPostBusinessEventListener(
+                LoanDelinquencyRangeChangeBusinessEvent.class,
+                new DelinquencyHookListener());
+    }
 
     @Override
     public CommandProcessingResult createDelinquencyRange(JsonCommand command) {
@@ -600,6 +621,52 @@ public class DelinquencyWritePlatformServiceImpl implements DelinquencyWritePlat
                     .filter(tag -> tag.getInstallment() == null).map(tag -> tag.getId()).toList();
             if (loanInstallmentTagsForDelete.size() > 0) {
                 loanInstallmentDelinquencyTagRepository.deleteAllLoanInstallmentsTagsByIds(loanInstallmentTagsForDelete);
+            }
+        }
+    }
+
+    private final class DelinquencyHookListener
+            implements BusinessEventListener<LoanDelinquencyRangeChangeBusinessEvent> {
+
+        @Override
+        public void onBusinessEvent(LoanDelinquencyRangeChangeBusinessEvent event) {
+            try {
+
+                Loan loan = event.get();
+
+                Map<String, Object> payload = new LinkedHashMap<>();
+
+                payload.put("loanId", loan.getId());
+                payload.put("clientId", loan.getClientId());
+
+                payload.put("entityName", "LOAN");
+                payload.put("actionName", "DELINQUENCYCHANGE");
+                payload.put("timestamp", Instant.now().toString());
+
+                AppUser appUser = context.authenticatedUser();
+
+                String serializedPayload =
+                        toApiResultJsonSerializer.serialize(payload);
+
+                HookEventSource hookEventSource =
+                        new HookEventSource("LOAN", "DELINQUENCYCHANGE");
+
+                HookEvent hookEvent =
+                        new HookEvent(
+                                hookEventSource,
+                                serializedPayload,
+                                appUser,
+                                ThreadLocalContextUtil.getContext());
+
+                applicationContext.publishEvent(hookEvent);
+
+                log.info(
+                        "Published HookEvent for delinquent loan {} (client {})",
+                        loan.getId(),
+                        loan.getClientId());
+
+            } catch (Exception e) {
+                log.error("Failed to publish delinquency HookEvent", e);
             }
         }
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/starter/DelinquencyConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/delinquency/starter/DelinquencyConfiguration.java
@@ -19,6 +19,8 @@
 package org.apache.fineract.portfolio.delinquency.starter;
 
 import org.apache.fineract.infrastructure.event.business.service.BusinessEventNotifierService;
+import org.apache.fineract.infrastructure.core.serialization.ToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketMappingsRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyBucketRepository;
 import org.apache.fineract.portfolio.delinquency.domain.DelinquencyRangeRepository;
@@ -42,6 +44,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.LoanRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -73,11 +76,13 @@ public class DelinquencyConfiguration {
             LoanDelinquencyDomainService loanDelinquencyDomainService,
             LoanInstallmentDelinquencyTagRepository loanInstallmentDelinquencyTagRepository,
             DelinquencyReadPlatformService delinquencyReadPlatformService, LoanDelinquencyActionRepository loanDelinquencyActionRepository,
-            DelinquencyActionParseAndValidator delinquencyActionParseAndValidator,
-            DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper) {
+                                                                           DelinquencyActionParseAndValidator delinquencyActionParseAndValidator,
+                                                                           DelinquencyEffectivePauseHelper delinquencyEffectivePauseHelper,
+                                                                           ApplicationContext applicationContext,PlatformSecurityContext context,
+                                                                           ToApiJsonSerializer<Object> toApiResultJsonSerializer) {
         return new DelinquencyWritePlatformServiceImpl(dataValidatorBucket, dataValidatorRange, repositoryRange, repositoryBucket,
                 repositoryBucketMappings, loanDelinquencyTagRepository, loanRepository, loanProductRepository, businessEventNotifierService,
-                loanDelinquencyDomainService, loanInstallmentDelinquencyTagRepository, delinquencyReadPlatformService,
+                applicationContext,context, toApiResultJsonSerializer,loanDelinquencyDomainService, loanInstallmentDelinquencyTagRepository, delinquencyReadPlatformService,
                 loanDelinquencyActionRepository, delinquencyActionParseAndValidator, delinquencyEffectivePauseHelper);
     }
 

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -155,4 +155,5 @@
     <include file="parts/0134_add_credentials_locked_at_column.xml" relativeToChangelogFile="true"/>
     <include file="parts/0135_add_encryption_keys.xml" relativeToChangelogFile="true"/>
     <include file="parts/0136_add_template_system_user.xml" relativeToChangelogFile="true"/>
+    <include file="parts/0137_add_system_users_configuration.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0136_add_template_system_user.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0136_add_template_system_user.xml
@@ -34,8 +34,6 @@ limitations under the License.
 
         <insert tableName="m_appuser">
 
-            <column name="id" valueNumeric="4"/>
-
             <column name="is_deleted" valueBoolean="false"/>
 
             <column name="office_id" valueNumeric="1"/>
@@ -90,8 +88,9 @@ limitations under the License.
 
         <insert tableName="m_appuser_role">
 
-            <column name="appuser_id"
-                    valueNumeric="4"/>
+            <column
+                    name="appuser_id"
+                    valueComputed="(SELECT id FROM m_appuser WHERE username='template_system')"/>
 
             <column name="role_id"
                     valueNumeric="1"/>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0137_add_system_users_configuration.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0137_add_system_users_configuration.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+
+    <changeSet id="0137" author="pareekshith">
+
+        <insert tableName="c_configuration">
+
+            <column name="name"
+                    value="system-users"/>
+
+            <column name="value"/>
+
+            <column name="date_value"/>
+
+            <column name="string_value"
+                    value="system,mifos,template_system"/>
+
+            <column name="enabled"
+                    valueBoolean="true"/>
+
+            <column name="is_trap_door"
+                    valueBoolean="false"/>
+
+            <column name="description"
+                    value="Comma-separated list of system/service usernames permitted to authenticate via Basic Auth for direct API access"/>
+
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
# Separate System Users and Application Users

## Summary

Implemented system-user and application-user separation for API authentication.

System users are now configurable through `c_configuration` and are allowed to authenticate using Basic Authentication, while application users are prevented from using Basic Authentication.

## Changes

### System User Configuration

- Added a new `system-users` configuration in `c_configuration`.
- Initial configured system users:
  - `system`
  - `mifos`
  - `template_system`
- System users can be extended through configuration without modifying Java code.

### Configuration Service

- Added `getSystemUsernames()` to `ConfigurationDomainService`.
- Implemented configuration lookup and comma-separated username parsing in `ConfigurationDomainServiceJpa`.
- Uses the existing configuration caching mechanism.

### Basic Authentication

Updated `TenantAwareBasicAuthenticationFilter` to:

- Allow Basic Authentication only for configured system users.
- Reject application users attempting to authenticate using Basic Authentication.

### Token Authentication

Updated `CustomTokenAuthenticationFilter` to:

- Reject configured system users attempting to authenticate using application tokens.
- Continue allowing application users through the normal token authentication flow.

## Modified Files

- `fineract-provider/src/main/resources/db/changelog/tenant/parts/0137_add_system_users_configuration.xml`
- `fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml`
- `fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainService.java`
- `fineract-provider/src/main/java/org/apache/fineract/infrastructure/configuration/domain/ConfigurationDomainServiceJpa.java`
- `fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/TenantAwareBasicAuthenticationFilter.java`
- `fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/filter/CustomTokenAuthenticationFilter.java`

## Verification

Verified the following authentication behavior:

- System user + Basic Auth → Allowed
- System user + Token Auth → Rejected
- Application user + Basic Auth → Rejected
- Application user + Token Auth → Allowed

Also verified that adding a user to the `system-users` configuration dynamically allows that user to authenticate as a system user.